### PR TITLE
Fix HttpSink bad response handling

### DIFF
--- a/flume-ng-sinks/flume-http-sink/src/main/java/org/apache/flume/sink/http/HttpSink.java
+++ b/flume-ng-sinks/flume-http-sink/src/main/java/org/apache/flume/sink/http/HttpSink.java
@@ -218,7 +218,12 @@ public class HttpSink extends AbstractSink implements Configurable {
           int httpStatusCode = connection.getResponseCode();
           LOG.debug("Got status code : " + httpStatusCode);
 
-          connection.getInputStream().close();
+          if (httpStatusCode < HttpURLConnection.HTTP_BAD_REQUEST) {
+            connection.getInputStream().close();
+          } else {
+            LOG.debug("bad request");
+            connection.getErrorStream().close();
+          }
           LOG.debug("Response processed and closed");
 
           if (httpStatusCode >= HTTP_STATUS_CONTINUE) {

--- a/flume-ng-sinks/flume-http-sink/src/test/java/org/apache/flume/sink/http/TestHttpSink.java
+++ b/flume-ng-sinks/flume-http-sink/src/test/java/org/apache/flume/sink/http/TestHttpSink.java
@@ -216,6 +216,22 @@ public class TestHttpSink {
   }
 
   @Test
+  public void ensureSingleErrorStatusConfigurationCorrectlyUsed() throws Exception {
+    when(channel.take()).thenReturn(event);
+    when(event.getBody()).thenReturn("something".getBytes());
+
+    Context context = new Context();
+    context.put("defaultRollback", "true");
+    context.put("defaultBackoff", "true");
+    context.put("defaultIncrementMetrics", "false");
+    context.put("rollback.401", "false");
+    context.put("backoff.401", "false");
+    context.put("incrementMetrics.401", "false");
+
+    executeWithMocks(true, Status.READY, false, true, context, HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
   public void ensureGroupConfigurationCorrectlyUsed() throws Exception {
     when(channel.take()).thenReturn(event);
     when(event.getBody()).thenReturn("something".getBytes());
@@ -278,6 +294,7 @@ public class TestHttpSink {
     when(channel.getTransaction()).thenReturn(transaction);
     when(httpURLConnection.getOutputStream()).thenReturn(outputStream);
     when(httpURLConnection.getInputStream()).thenReturn(inputStream);
+    when(httpURLConnection.getErrorStream()).thenReturn(inputStream);
     when(httpURLConnection.getResponseCode()).thenReturn(httpStatus);
 
     Status actualStatus = httpSink.process();


### PR DESCRIPTION
After a bad response, connection.getInputStream() returns null.
This patch adds a check for this.

This closes #139

Reviewers: Bessenyei Balázs Donát

(filippovmn via Bessenyei Balázs Donát)