### PR TITLE
FLUME-3159. Setting JdbcChannel test connection to in-memory derby

### DIFF
--- a/flume-ng-channels/flume-jdbc-channel/src/test/java/org/apache/flume/channel/jdbc/BaseJdbcChannelProviderTest.java
+++ b/flume-ng-channels/flume-jdbc-channel/src/test/java/org/apache/flume/channel/jdbc/BaseJdbcChannelProviderTest.java
@@ -86,7 +86,7 @@ public abstract class BaseJdbcChannelProviderTest {
     }
 
     derbyCtx.put(ConfigurationConstants.CONFIG_URL,
-        "jdbc:derby:" + derbyDbDir.getCanonicalPath() + "/db;create=true");
+        "jdbc:derby:memory:" + derbyDbDir.getCanonicalPath() + "/db;create=true");
 
     configureChannel(derbyCtx);
 


### PR DESCRIPTION
This patch changes the JdbcChannel tests to use in-memory derby to make parallel
test run possible.

This closes #177

Reviewers: Denes Arvay

(Ferenc Szabo via Denes Arvay)